### PR TITLE
Improve local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 ._DS_Store
-config.json

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,8 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.7-buster-build
 
+WORKDIR /usr/app
+COPY pip.conf /etc/
+
 RUN install_packages \
         jq \
         moreutils \
@@ -8,13 +11,12 @@ RUN install_packages \
         libjpeg-dev \
         libtiff5
 
-WORKDIR /usr/app
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY src ./src
 COPY balena-run.sh ./
-COPY config.sample.json ./
+COPY config.json ./
 
 RUN chmod +x balena-run.sh
 

--- a/balena-run.sh
+++ b/balena-run.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
-if [ ! -f config.json ]; then
-  cp config.sample.json config.json
+if [[ ! -z "${departureStation}" ]]; then
   jq .journey.departureStation=\""${departureStation}"\" config.json | sponge config.json
+fi
+
+if [[ ! -z "${destinationStation}" ]]; then
   jq .journey.destinationStation=\""${destinationStation}"\" config.json | sponge config.json
+fi
+
+if [[ ! -z "${outOfHoursName}" ]]; then
   jq .journey.outOfHoursName=\""${outOfHoursName}"\" config.json | sponge config.json
+fi
+
+if [[ ! -z "${refreshTime}" ]]; then
   jq .refreshTime="${refreshTime}" config.json | sponge config.json
+fi
+
+if [[ ! -z "${transportApi_appId}" ]]; then
   jq .transportApi.appId=\""${transportApi_appId}"\" config.json | sponge config.json
+fi
+
+if [[ ! -z "${transportApi_apiKey}" ]]; then
   jq .transportApi.apiKey=\""${transportApi_apiKey}"\" config.json | sponge config.json
+fi
+
+if [[ ! -z "${transportApi_operatingHours}" ]]; then
   jq .transportApi.operatingHours=\""${transportApi_operatingHours}"\" config.json | sponge config.json
 fi
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
   "journey": {
-    "departureStation": "",
+    "departureStation": "PAD",
     "destinationStation": null,
+    "outOfHoursName": "London Paddington",
     "stationAbbr": {
       "International": "Intl."
     }

--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,2 @@
+[global]
+extra-index-url=https://www.piwheels.org/simple


### PR DESCRIPTION
Fixes #18 

Add a config.json which is used for default variables (meaning they are not required to be specified on commandline).
Make balena-run.sh override config.json with any environment variables that *are* set
Add use of PiWheels making local builds on Pi Zero much much faster (a few minutes for a clean build)

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>