### PR TITLE
Add numericPlatformsOnly flag and multiple destination station support

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -79,6 +79,7 @@ data:
     - TZ: Europe/London
     - departureStation: PAD
     - outOfHoursName: London Paddington
+    - numericPlatformsOnly: false
     - refreshTime: 120
     - apiKey: UPDATE_ME
     - operatingHours: 8-22

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -23,7 +23,7 @@ These environment variables are specified using the [balenaCloud dashboard](http
 | `screen1Platform` | `1` (sets the platform you want to have displayed on the first or single-screen display)
 | `screen2Platform` | `2` (sets the platform you want to have displayed on the second display)
 | `individualStationDepartureTime` | `False` (Displays the estimated or scheduled time of the service at each leg of a journey)
-| `numericPlatformsOnly` | This will only show numeric platforms, some stations may have local services that use alphabetic stations for local services (this will remove stations like 3A, 4B).
+| `numericPlatformsOnly` | `False` This will only show numeric platforms, some stations may have local services that use alphabetic stations for local services (this will remove stations like 3A, 4B).
 | `fpsTime` | `4` (adjusts how often the effective FPS is displayed)
 | `headless` | `True` (outputs to noop serial device rather than serial port; useful for running on a development machine)
 | `showDepartureNumbers` | `True` (adds 1st / 2nd / 3rd as per UK train departures)

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -12,7 +12,7 @@ These environment variables are specified using the [balenaCloud dashboard](http
 |`apiKey` **(REQUIRED)** | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` (OpenLDBWS API key)
 |`TZ`  | `Europe/London`, will default to UTC if not set ([timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
 |`departureStation`  | `PAD` ([station code](https://www.nationalrail.co.uk/stations_destinations/48541.aspx))
-|`destinationStation`  | `HWV` ([station code](https://www.nationalrail.co.uk/stations_destinations/48541.aspx)) [optional] Filters trains shown to only those that call at this station
+|`destinationStation`  | `HWV` ([station code](https://www.nationalrail.co.uk/stations_destinations/48541.aspx)) [optional] Filters trains shown to only those that call at this station. This can be multiple stations seperated by a comma. eg. PAD, KGX, STP
 |`timeOffset`  | `5` [optional] (Time offset, in minutes, for the departure board. Can be used to see into the future (positive value) or past (negative value). Set 5 if you live 5 min from the station and want to hide departures that are too soon to catch)
 |`refreshTime` | `120` (seconds between data refresh)
 |`screenRotation` | `2` (rotates the output of the OLED, 0 for when using the desk stand, 2 for the monitor mount ([docs](https://luma-oled.readthedocs.io/en/latest/api-documentation.html#luma.oled.device.ssd1322)))
@@ -23,6 +23,7 @@ These environment variables are specified using the [balenaCloud dashboard](http
 | `screen1Platform` | `1` (sets the platform you want to have displayed on the first or single-screen display)
 | `screen2Platform` | `2` (sets the platform you want to have displayed on the second display)
 | `individualStationDepartureTime` | `False` (Displays the estimated or scheduled time of the service at each leg of a journey)
+| `numericPlatformsOnly` | This will only show numeric platforms, some stations may have local services that use alphabetic stations for local services (this will remove stations like 3A, 4B).
 | `fpsTime` | `4` (adjusts how often the effective FPS is displayed)
 | `headless` | `True` (outputs to noop serial device rather than serial port; useful for running on a development machine)
 | `showDepartureNumbers` | `True` (adds 1st / 2nd / 3rd as per UK train departures)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ luma.oled
 timeloop
 requests
 xmltodict
+defusedxml
 RPi.GPIO
 spidev
 cbor2>=5.8.0

--- a/src/config.py
+++ b/src/config.py
@@ -43,8 +43,10 @@ def loadConfig():
     data["journey"]["departureStation"] = os.getenv("departureStation") or "PAD"
 
     data["journey"]["destinationStation"] = os.getenv("destinationStation") or ""
-    if data["journey"]["destinationStation"] == "null" or data["journey"]["destinationStation"] == "undefined":
-        data["journey"]["destinationStation"] = ""
+    if data["journey"]["destinationStation"] and data["journey"]["destinationStation"] not in ("null", "undefined"):
+        data["journey"]["destinationStation"] = [s.strip() for s in data["journey"]["destinationStation"].split(",")]
+    else:
+        data["journey"]["destinationStation"] = [""]
 
     data["journey"]["individualStationDepartureTime"] = False
     if os.getenv("individualStationDepartureTime", "").upper() == "TRUE":
@@ -55,7 +57,8 @@ def loadConfig():
     data["journey"]['timeOffset'] = os.getenv("timeOffset") or "0"
     data["journey"]["screen1Platform"] = parsePlatformData(os.getenv("screen1Platform"))
     data["journey"]["screen2Platform"] = parsePlatformData(os.getenv("screen2Platform"))
-
+    data["journey"]["numericPlatformsOnly"] = os.getenv("numericPlatformsOnly", "False").lower() == "true"
+    
     data["api"]["apiKey"] = os.getenv("apiKey") or None
     data["api"]["operatingHours"] = os.getenv("operatingHours") or ""
 

--- a/src/main.py
+++ b/src/main.py
@@ -319,7 +319,7 @@ def drawDebugScreen(device, width, height, screen="1", showTime=False):
 
     # has a destination been set? add it in!
     if(config["journey"]["destinationStation"]):
-        debugLines["1B"] += f"->{config['journey']['destinationStation']}"
+        debugLines["1B"] += f"->{','.join(config['journey']['destinationStation'])}"
 
     # what about a plaform?
     if(config["journey"]["screen"+screen+"Platform"]):
@@ -381,25 +381,24 @@ def drawBlankSignage(device, width, height, departureStation):
 
     return virtualViewport
 
-
-def platform_filter(departureData, platformNumber, station):
+def platform_filter(departureData, platformNumber, station, numericOnly=False):
     platformDepartures = []
     for sub in departureData:
-        if platformNumber == "":
+        if numericOnly:
+            if sub.get('platform') is not None and sub['platform'].isdigit():
+                platformDepartures.append(sub)
+        elif platformNumber == "":
             platformDepartures.append(sub)
         elif sub.get('platform') is not None:
             if sub['platform'] == platformNumber:
                 res = sub
                 platformDepartures.append(res)
-
     if len(platformDepartures) > 0:
         firstDepartureDestinations = platformDepartures[0]["calling_at_list"]
         platformData = platformDepartures, firstDepartureDestinations, station
     else:
         platformData = platformDepartures, "", station
-
     return platformData
-
 
 def drawSignage(device, width, height, data, screen_id='default'):
     virtualViewport = viewport(device, width=width, height=height)
@@ -478,7 +477,7 @@ def drawSignage(device, width, height, data, screen_id='default'):
 
 def getIp():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.settimeout(0)
+    s.settimeout(1)
     try:
         # doesn't even have to be reachable
         s.connect(('10.254.254.254', 1))
@@ -582,11 +581,11 @@ try:
                             departureData = data[0]
                             nextStations = data[1]
                             station = data[2]
-                            screenData = platform_filter(departureData, config["journey"]["screen1Platform"], station)
+                            screenData = platform_filter(departureData, config["journey"]["screen1Platform"], station, config["journey"]["numericPlatformsOnly"])
                             virtual = drawSignage(device, width=widgetWidth, height=widgetHeight, data=screenData, screen_id='screen1')
 
                             if config['dualScreen']:
-                                screen1Data = platform_filter(departureData, config["journey"]["screen2Platform"], station)
+                                screen1Data = platform_filter(departureData, config["journey"]["screen2Platform"], station, config["journey"]["numericPlatformsOnly"])
                                 virtual1 = drawSignage(device1, width=widgetWidth, height=widgetHeight, data=screen1Data, screen_id='screen2')
 
                     timeAtStart = time.time()

--- a/src/trains.py
+++ b/src/trains.py
@@ -1,7 +1,21 @@
 import requests
 import re
 import xmltodict
+import defusedxml
+defusedxml.defuse_stdlib()
 
+
+def escapeXml(value):
+    """Escape XML special characters to prevent XML injection"""
+    if value is None:
+        return ""
+    value = str(value)
+    value = value.replace("&", "&amp;")
+    value = value.replace("<", "&lt;")
+    value = value.replace(">", "&gt;")
+    value = value.replace("\"", "&quot;")
+    value = value.replace("'", "&apos;")
+    return value
 
 def removeBrackets(originalName):
     return re.split(r" \(", originalName)[0]
@@ -209,28 +223,41 @@ def loadDeparturesForStation(journeyConfig, apiKey, rows):
         raise ValueError(
             "Please configure the apiKey environment variable")
 
-    APIRequest = """
+    destinations = journeyConfig["destinationStation"]
+    allDepartures = []
+    departureStationName = ""
+    seenServices = set()
+
+    for destination in destinations:
+        APIRequest = """
         <x:Envelope xmlns:x="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ldb="http://thalesgroup.com/RTTI/2017-10-01/ldb/" xmlns:typ4="http://thalesgroup.com/RTTI/2013-11-28/Token/types">
         <x:Header>
-            <typ4:AccessToken><typ4:TokenValue>""" + apiKey + """</typ4:TokenValue></typ4:AccessToken>
+            <typ4:AccessToken><typ4:TokenValue>""" + escapeXml(apiKey) + """</typ4:TokenValue></typ4:AccessToken>
         </x:Header>
         <x:Body>
             <ldb:GetDepBoardWithDetailsRequest>
-                <ldb:numRows>""" + rows + """</ldb:numRows>
-                <ldb:crs>""" + journeyConfig["departureStation"] + """</ldb:crs>
-                <ldb:timeOffset>""" + journeyConfig["timeOffset"] + """</ldb:timeOffset>
-                <ldb:filterCrs>""" + journeyConfig["destinationStation"] + """</ldb:filterCrs>
+                <ldb:numRows>""" + escapeXml(rows) + """</ldb:numRows>
+                <ldb:crs>""" + escapeXml(journeyConfig["departureStation"]) + """</ldb:crs>
+                <ldb:timeOffset>""" + escapeXml(journeyConfig["timeOffset"]) + """</ldb:timeOffset>
+                <ldb:filterCrs>""" + escapeXml(destination) + """</ldb:filterCrs>
                 <ldb:filterType>to</ldb:filterType>
                 <ldb:timeWindow>120</ldb:timeWindow>
             </ldb:GetDepBoardWithDetailsRequest>
         </x:Body>
     </x:Envelope>"""
 
-    headers = {'Content-Type': 'text/xml'}
-    apiURL = "https://lite.realtime.nationalrail.co.uk/OpenLDBWS/ldb11.asmx"
+        headers = {'Content-Type': 'text/xml'}
+        apiURL = "https://lite.realtime.nationalrail.co.uk/OpenLDBWS/ldb11.asmx"
+        APIOut = requests.post(apiURL, data=APIRequest, headers=headers, timeout=10).text
+        Departures, departureStationName = ProcessDepartures(journeyConfig, APIOut)
 
-    APIOut = requests.post(apiURL, data=APIRequest, headers=headers).text
+        if Departures:
+            for departure in Departures:
+                key = departure["aimed_departure_time"] + departure["destination_name"]
+                if key not in seenServices:
+                    seenServices.add(key)
+                    allDepartures.append(departure)
 
-    Departures, departureStationName = ProcessDepartures(journeyConfig, APIOut)
+    allDepartures = sorted(allDepartures, key=lambda x: x["aimed_departure_time"])
 
-    return Departures, departureStationName
+    return allDepartures if allDepartures else None, departureStationName


### PR DESCRIPTION
## **Add `numericPlatformsOnly` flag and multiple destination station support**

**Summary**

This PR adds two new features, adding the ability to add multiple destination stations in a comma separated list and also the ability to select numeric only platforms, alongside some security improvements picked up during development.

**1. Numeric platforms only**

Adds a new boolean environment variable `numericPlatformsOnly` which when set to `True` filters out any departures from platforms with non-numeric identifiers. This is particularly useful at stations like Liverpool Lime Street where local Merseyrail services use lettered platforms (A, B, C) and mainline services use numbered platforms (1-9).

**2. Multiple destination stations**

Updates `destinationStation` to accept a comma-separated list of station codes (e.g. `MAN,LIV,BHM`). Each destination triggers a separate API call and results are deduplicated by departure time and destination name, then sorted chronologically. Single station codes continue to work exactly as before.

**3. Security improvements**

- Added `defusedxml` to patch the standard XML libraries used by `xmltodict` when parsing API responses, protecting against XML-based attacks such as entity expansion and external entity injection
- Added `escapeXml()` function to sanitise all user-supplied values before they are interpolated into the SOAP XML request, preventing XML injection
- Added `timeout=10` to the API request to prevent indefinite hangs on unresponsive connections
- Scanned codebase with Bandit (Python security linter) — no issues identified

**Changes**

- `src/config.py` - Added `numericPlatformsOnly` config loading; updated `destinationStation` to parse comma-separated values into a list; removed redundant `"numeric"` workaround from `parsePlatformData`
- `src/main.py` - Updated `platform_filter` to accept `numericOnly` parameter; updated both `platform_filter` call sites to pass the new flag
- `src/trains.py` - Updated `loadDeparturesForStation` to loop through multiple destinations, deduplicate and sort merged results; added `escapeXml()` sanitisation and request timeout
- `balena.yml` - Added `numericPlatformsOnly` environment variable definition
- `requirements.txt` - Added `defusedxml` dependency

**API usage**

Multiple destinations make one API call per destination per refresh cycle. With the OpenLDBWS 5 million request limit per 4-week period this is not a concern even with several destinations configured.

**Backwards compatibility**

All changes are fully backwards compatible. Both new variables are optional and default to their original behaviour if not set.

Should close issue #126 